### PR TITLE
Add process priority to general settings

### DIFF
--- a/src/xxmi_launcher/core/packages/migoto_package.py
+++ b/src/xxmi_launcher/core/packages/migoto_package.py
@@ -96,6 +96,20 @@ class MigotoPackage(Package):
         dll_path = Config.Active.Importer.importer_path / 'd3d11.dll'
         launch_cmd = event.start_cmd.split() + Config.Active.Importer.launch_options.split()
 
+        creationflags = None
+        if Config.Active.Importer.run_process_priority == 'Low'
+            creationflags = subprocess.IDLE_PRIORITY_CLASS
+        elif Config.Active.Importer.run_process_priority == 'Below Normal'
+            creationflags = subprocess.BELOW_NORMAL_PRIORITY_CLASS
+        elif Config.Active.Importer.run_process_priority == 'Normal'
+            creationflags = subprocess.NORMAL_PRIORITY_CLASS
+        elif Config.Active.Importer.run_process_priority == 'Above Normal'
+            creationflags = subprocess.ABOVE_NORMAL_PRIORITY_CLASS
+        elif Config.Active.Importer.run_process_priority == 'High'
+            creationflags = subprocess.HIGH_PRIORITY_CLASS
+        elif Config.Active.Importer.run_process_priority == 'Realtime'
+            creationflags = subprocess.REALTIME_PRIORITY_CLASS
+
         extra_dll_paths = []
         if Config.Active.Importer.extra_libraries_enabled:
             extra_dll_paths += Config.Active.Importer.extra_dll_paths
@@ -111,9 +125,9 @@ class MigotoPackage(Package):
                 # Start game's exe
                 Events.Fire(Events.Application.StartGameExe(process_name=event.exe_path.name))
                 if len(extra_dll_paths) == 0:
-                    subprocess.Popen(launch_cmd)
+                    subprocess.Popen(launch_cmd, creationflags=creationflags)
                 else:
-                    pid = direct_inject(dll_paths=extra_dll_paths, process_name=event.exe_path.name, start_cmd=launch_cmd)
+                    pid = direct_inject(dll_paths=extra_dll_paths, process_name=event.exe_path.name, start_cmd=launch_cmd, creationflags=creationflags)
                     if pid == -1:
                         raise ValueError(f'Failed to inject {str(extra_dll_paths)}!')
 
@@ -144,7 +158,7 @@ class MigotoPackage(Package):
             # Use WriteProcessMemory injection method
             Events.Fire(Events.Application.Inject(library_name=dll_path.name, process_name=event.exe_path.name))
             dll_paths = [dll_path] + extra_dll_paths
-            pid = direct_inject(dll_paths=dll_paths, process_name=event.exe_path.name, start_cmd=launch_cmd)
+            pid = direct_inject(dll_paths=dll_paths, process_name=event.exe_path.name, start_cmd=launch_cmd, creationflags=creationflags)
             if pid == -1:
                 raise ValueError(f'Failed to inject {dll_path.name}!')
 

--- a/src/xxmi_launcher/core/packages/model_importers/model_importer.py
+++ b/src/xxmi_launcher/core/packages/model_importers/model_importer.py
@@ -47,6 +47,7 @@ class ModelImporterConfig:
     game_folder: str = ''
     launcher_theme: str = 'Default'
     overwrite_ini: bool = True
+    run_process_priority: str = 'Default'
     run_pre_launch_enabled: bool = True
     run_pre_launch: str = ''
     run_pre_launch_signature: str = ''

--- a/src/xxmi_launcher/core/utils/dll_injector.py
+++ b/src/xxmi_launcher/core/utils/dll_injector.py
@@ -105,9 +105,9 @@ class DllInjector:
         return True
 
 
-def direct_inject(dll_paths: List[Path], process_name: str = None, pid: int = None, start_cmd: list = None, timeout: int = 15):
+def direct_inject(dll_paths: List[Path], process_name: str = None, pid: int = None, start_cmd: list = None, timeout: int = 15, creationflags: int = None):
     if start_cmd:
-        subprocess.Popen(start_cmd)
+        subprocess.Popen(start_cmd, creationflags=creationflags)
 
     time_start = time.time()
 

--- a/src/xxmi_launcher/gui/classes/widgets.py
+++ b/src/xxmi_launcher/gui/classes/widgets.py
@@ -518,6 +518,14 @@ class UICheckbox(CTkCheckBox, UIWidget):
             raise ValueError(f'Failed to set checkbox to unknown value {value}!')
 
 
+class UIOptionMenu(CTkOptionMenu, UIWidget):
+    def __init__(self,
+                 master: Union[UIWindow, 'UIFrame'],
+                 **kwargs):
+        UIWidget.__init__(self, master,  **kwargs)
+        CTkOptionMenu.__init__(self, master, **kwargs)
+
+
 class UITextbox(CTkTextbox, UIWidget):
     def __init__(self,
                  master: Union[UIWindow, 'UIFrame'],

--- a/src/xxmi_launcher/gui/windows/settings/frames/general_settings_frame.py
+++ b/src/xxmi_launcher/gui/windows/settings/frames/general_settings_frame.py
@@ -16,8 +16,8 @@ class GeneralSettingsFrame(UIFrame):
 
         self.grid_columnconfigure((0, 2), weight=1)
         self.grid_columnconfigure(1, weight=100)
-        self.grid_rowconfigure((0, 1, 2), weight=1)
-        self.grid_rowconfigure(5, weight=100)
+        self.grid_rowconfigure((0, 1, 2, 3), weight=1)
+        self.grid_rowconfigure(6, weight=100)
 
         # Game Folder
         self.put(GameFolderLabel(self)).grid(row=0, column=0, padx=(20, 0), pady=(20, 20), sticky='wn')
@@ -25,18 +25,22 @@ class GeneralSettingsFrame(UIFrame):
         self.put(GameFolderEntry(self, game_folder_error)).grid(row=0, column=1, padx=20, pady=(20, 20), sticky='ewn')
         self.put(ChangeGameFolderButton(self)).grid(row=0, column=2, padx=(0, 20), pady=(20, 20), sticky='n')
 
+        # Process Priority
+        self.put(ProcessPriorityLabel(self)).grid(row=1, column=0, padx=(20, 10), pady=(20, 20), sticky='w')
+        self.put(ProcessPriorityOptionMenu(self)).grid(row=1, column=1, padx=20, pady=(20, 20), sticky='ew', columnspan=2)
+
         # Launch Options
-        self.put(LaunchOptionsLabel(self)).grid(row=1, column=0, padx=(20, 10), pady=(20, 20), sticky='w')
-        self.put(LaunchOptionsEntry(self)).grid(row=1, column=1, padx=20, pady=(20, 20), sticky='ew', columnspan=2)
+        self.put(LaunchOptionsLabel(self)).grid(row=2, column=0, padx=(20, 10), pady=(20, 20), sticky='w')
+        self.put(LaunchOptionsEntry(self)).grid(row=2, column=1, padx=20, pady=(20, 20), sticky='ew', columnspan=2)
 
         #  Extra
-        self.put(AutoCloseCheckbox(self)).grid(row=2, column=1, padx=(20, 10), pady=(10, 20), sticky='w', columnspan=2)
+        self.put(AutoCloseCheckbox(self)).grid(row=3, column=1, padx=(20, 10), pady=(10, 20), sticky='w', columnspan=2)
         if Vars.Launcher.active_importer.get() == 'WWMI':
-            self.put(ApplyTweaksCheckbox(self)).grid(row=3, column=1, padx=(20, 10), pady=(10, 20), sticky='w', columnspan=2)
-            self.put(OpenEngineIniButton(self)).grid(row=3, column=1, padx=(260, 0), pady=(10, 20), sticky='w', columnspan=2)
+            self.put(ApplyTweaksCheckbox(self)).grid(row=4, column=1, padx=(20, 10), pady=(10, 20), sticky='w', columnspan=2)
+            self.put(OpenEngineIniButton(self)).grid(row=4, column=1, padx=(260, 0), pady=(10, 20), sticky='w', columnspan=2)
 
         if Vars.Launcher.active_importer.get() in ['WWMI', 'SRMI', 'GIMI']:
-            self.put(UnlockFPSCheckbox(self)).grid(row=4, column=1, padx=(20, 10), pady=(10, 20), sticky='w', columnspan=2)
+            self.put(UnlockFPSCheckbox(self)).grid(row=5, column=1, padx=(20, 10), pady=(10, 20), sticky='w', columnspan=2)
 
 
 class GameFolderLabel(UILabel):
@@ -116,6 +120,30 @@ class ChangeGameFolderButton(UIButton):
         if game_folder == '':
             return
         Vars.Active.Importer.game_folder.set(game_folder)
+
+
+class ProcessPriorityLabel(UILabel):
+    def __init__(self, master):
+        super().__init__(
+            text='Process Priority:',
+            font=('Roboto', 16, 'bold'),
+            fg_color='transparent',
+            master=master)
+
+
+class ProcessPriorityOptionMenu(UIOptionMenu):
+    def __init__(self, master):
+        super().__init__(
+            values=['Default', 'Low', 'Below Normal', 'Normal', 'Above Normal', 'High', 'Realtime'],
+            variable=Vars.Active.Importer.run_process_priority,
+            width=200,
+            height=36,
+            font=('Arial', 14),
+            dropdown_font=('Arial', 14),
+            master=master)
+        # self.trace_write(Vars.Active.Migoto.unsafe_mode, self.handle_unsafe_mode_update)
+        self.set_tooltip(
+            'Set Windows process scheduler CPU priority for the game exe.')
 
 
 class LaunchOptionsLabel(UILabel):


### PR DESCRIPTION
This _should_ add "Process Priority" option menu to games' "General Settings" popup; **however, this is untested because of a lack of dependencies.** There is no requirements.txt, and pipreqs failed to parse imports from source code.

This new functionality is important, especially for ZZZ, which for whatever reason often defaults to "Below Normal" process priority, which also cannot be changed by normal means post-launch due to anti-cheat. My tests on this from ZZZ patch 1.0 found 50% increased avg fps (75 → 115) in Lumina Square when increasing process priority from Below Normal to Above Normal.

If you are against this feature, a workaround that still lets users use your launcher with process priority boost would be to install Process Lasso 15.0.0.50+ (Sep 3, 2024) and enable the new "Enforce by registry" option.